### PR TITLE
Fix import path {github.com/rsc/qr ➜ rsc.io/qr}

### DIFF
--- a/qrterminal.go
+++ b/qrterminal.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/rsc/qr"
+	"rsc.io/qr"
 )
 
 const WHITE = "\033[47m  \033[0m"


### PR DESCRIPTION
I was trying to `go get github.com/claudiodangelis/qr-filetransfer` but got an unexpected error:
```
➜ GOPATH=~/installs/go-tools go get -u -v github.com/claudiodangelis/qr-filetransfer
github.com/claudiodangelis/qr-filetransfer (download)
github.com/jhoonb/archivex (download)
github.com/mattn/go-colorable (download)
github.com/mattn/go-isatty (download)
github.com/mdp/qrterminal (download)
github.com/rsc/qr (download)
package github.com/rsc/qr: code in directory /home/suhaskaranth/installs/go-tools/src/github.com/rsc/qr expects import "rsc.io/qr"
```

There was a recent commit [`ca9a01fc`](https://github.com/rsc/qr/commit/ca9a01fc2f9505024045632c50e5e8cd6142fafe) to `github.com/rsc/qr` which probably caused the issue. But the import path was incorrect to begin with and probably worked by downloading `rsc.io/pr` as a dependency of `github.com/rsc/qr`.

This PR corrects the import path for the qr dependency.