### PR TITLE
Add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/mdp/qrterminal
+
+require rsc.io/qr v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+rsc.io/qr v0.2.0 h1:6vBLea5/NRMVTz8V66gipeLycZMl/+UlFmk8DvqQ6WY=
+rsc.io/qr v0.2.0/go.mod h1:IF+uZjkb9fqyeF/4tlBoynqmQxUoPfWEKh921coOuXs=


### PR DESCRIPTION
consider making a v1.0.1 release?
by default, go modules would uses version v1.0.0, but it gots a import issue that was fixed in 6ff8cb7