### PR TITLE
add version string to module path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.0
+
+Adjust go.mod to include required version string
+
 ## 2.0.1
 
 Add goreleaser and release to Homebrew and Github

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ For command line usage [see below](https://github.com/mdp/qrterminal#command-lin
 
 As a library in an application
 
-`go get github.com/mdp/qrterminal`
+`go get github.com/mdp/qrterminal/v3`
 
 ## Usage
 
 ```go
 import (
-    "github.com/mdp/qrterminal"
+    "github.com/mdp/qrterminal/v3"
     "os"
     )
 
@@ -40,7 +40,7 @@ func main() {
 Large Inverted barcode with medium redundancy and a 1 pixel border
 ```go
 import (
-    "github.com/mdp/qrterminal"
+    "github.com/mdp/qrterminal/v3"
     "os"
     )
 
@@ -59,7 +59,7 @@ func main() {
 HalfBlock barcode with medium redundancy
 ```go
 import (
-    "github.com/mdp/qrterminal"
+    "github.com/mdp/qrterminal/v3"
     "os"
     )
 
@@ -82,7 +82,7 @@ OSX: `brew install mdp/tap/qrterminal`
 
 Others: Download from the [releases page](https://github.com/mdp/qrterminal/releases)
 
-Source: `go get -u github.com/mdp/qrterminal/cmd/qrterminal`
+Source: `go get -u github.com/mdp/qrterminal/v3/cmd/qrterminal`
 
 #### Usage
 

--- a/cmd/qrterminal/main.go
+++ b/cmd/qrterminal/main.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/mattn/go-colorable"
-	"github.com/mdp/qrterminal"
+	"github.com/mdp/qrterminal/v3"
 	"rsc.io/qr"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
-module github.com/mdp/qrterminal
+module github.com/mdp/qrterminal/v3
 
 require (
 	github.com/mattn/go-colorable v0.1.2
+	github.com/mdp/qrterminal v1.0.1
 	rsc.io/qr v0.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mdp/qrterminal v1.0.1 h1:07+fzVDlPuBlXS8tB0ktTAyf+Lp1j2+2zK3fBOL5b7c=
+github.com/mdp/qrterminal v1.0.1/go.mod h1:Z33WhxQe9B6CdW37HaVqcRKzP+kByF3q/qLxOGe12xQ=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223 h1:DH4skfRX4EBpamg7iV4ZlCpblAHI6s6TDM39bFZumv8=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 rsc.io/qr v0.2.0 h1:6vBLea5/NRMVTz8V66gipeLycZMl/+UlFmk8DvqQ6WY=


### PR DESCRIPTION
Go module support requires that versions greater than 1 include the major version in their module path.

This PR increments the version and adds it to the module path in go.mod, the README, and in internal imports.