### PR TITLE
Add Sixel Output for Compatible Terminal.

### DIFF
--- a/cmd/qrterminal/main.go
+++ b/cmd/qrterminal/main.go
@@ -60,7 +60,7 @@ func main() {
 		BlackChar: qrterminal.BLACK,
 		WhiteChar: qrterminal.WHITE,
 	}
-
+	cfg.WithSixel = qrterminal.IsSixelSupported(os.Stdout)
 	if verboseFlag {
 		fmt.Fprintf(os.Stdout, "Level: %s \n", levelFlag)
 		fmt.Fprintf(os.Stdout, "Quietzone Border Size: %d \n", quietZoneFlag)

--- a/cmd/qrterminal/main.go
+++ b/cmd/qrterminal/main.go
@@ -16,6 +16,7 @@ import (
 var verboseFlag bool
 var levelFlag string
 var quietZoneFlag int
+var sixelDisableFlag bool
 
 func getLevel(s string) qr.Level {
 	switch l := strings.ToLower(s); l {
@@ -34,6 +35,7 @@ func main() {
 	flag.BoolVar(&verboseFlag, "v", false, "Output debugging information")
 	flag.StringVar(&levelFlag, "l", "L", "Error correction level")
 	flag.IntVar(&quietZoneFlag, "q", 2, "Size of quietzone border")
+	flag.BoolVar(&sixelDisableFlag, "s", false, "disable sixel format for output")
 
 	flag.Parse()
 	level := getLevel(levelFlag)
@@ -60,7 +62,9 @@ func main() {
 		BlackChar: qrterminal.BLACK,
 		WhiteChar: qrterminal.WHITE,
 	}
-	cfg.WithSixel = qrterminal.IsSixelSupported(os.Stdout)
+	if !sixelDisableFlag {
+		cfg.WithSixel = qrterminal.IsSixelSupported(os.Stdout)
+	}
 	if verboseFlag {
 		fmt.Fprintf(os.Stdout, "Level: %s \n", levelFlag)
 		fmt.Fprintf(os.Stdout, "Quietzone Border Size: %d \n", quietZoneFlag)

--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,6 @@ require (
 
 require (
 	github.com/mattn/go-isatty v0.0.19 // indirect
-	golang.org/x/sys v0.8.0 // indirect
+	golang.org/x/sys v0.13.0 // indirect
+	golang.org/x/term v0.13.0
 )

--- a/go.sum
+++ b/go.sum
@@ -13,5 +13,9 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.13.0 h1:bb+I9cTfFazGW51MZqBVmZy7+JEJMouUHTUSKVQLBek=
+golang.org/x/term v0.13.0/go.mod h1:LTmsnFJwVN6bCy1rVCoS+qHT1HhALEFxKncY3WNNh4U=
 rsc.io/qr v0.2.0 h1:6vBLea5/NRMVTz8V66gipeLycZMl/+UlFmk8DvqQ6WY=
 rsc.io/qr v0.2.0/go.mod h1:IF+uZjkb9fqyeF/4tlBoynqmQxUoPfWEKh921coOuXs=

--- a/qrterminal.go
+++ b/qrterminal.go
@@ -32,6 +32,7 @@ const QUIET_ZONE = 4
 // Color 0: Black Color 1: White
 const SIXEL_BEGIN = "\x1bPq\n#0;2;0;0;0#1;2;100;100;100\n"
 const SIXEL_END = "\x1b\\"
+
 // Sixel Block Size, should be always greater than 6.
 const SIXEL_BLOCK_SIZE = 12
 
@@ -78,7 +79,7 @@ func IsSixelSupported(w io.Writer) bool {
 }
 
 func (c *Config) writeSixel(w io.Writer, code *qr.Code) {
-	line := SIXEL_BLOCK_SIZE/6
+	line := SIXEL_BLOCK_SIZE / 6
 	// Frame the barcode in a 1 pixel border
 	w.Write([]byte(SIXEL_BEGIN))
 	w.Write([]byte(stringRepeat(fmt.Sprintf("#1!%d~-\n", SIXEL_BLOCK_SIZE*(code.Size+c.QuietZone*2)), c.QuietZone*line))) // top border
@@ -117,7 +118,10 @@ func (c *Config) writeSixel(w io.Writer, code *qr.Code) {
 			w.Write(content.Bytes())
 		}
 	}
-	w.Write([]byte(stringRepeat(fmt.Sprintf("#1!%d~-\n", SIXEL_BLOCK_SIZE*(code.Size+c.QuietZone*2)), (c.QuietZone)*line))) // bottom border
+	w.Write([]byte(stringRepeat(fmt.Sprintf("#1!%d~-\n", SIXEL_BLOCK_SIZE*(code.Size+c.QuietZone*2)), (c.QuietZone-1)*line))) // bottom border
+	if c.QuietZone > 1 {
+		w.Write([]byte(fmt.Sprintf("#1!%d~-", SIXEL_BLOCK_SIZE*(code.Size+c.QuietZone*2)))) // bottom border last line, Fix on iTerm2
+	}
 	defer w.Write([]byte(SIXEL_END))
 }
 

--- a/qrterminal.go
+++ b/qrterminal.go
@@ -117,7 +117,7 @@ func (c *Config) writeSixel(w io.Writer, code *qr.Code) {
 			w.Write(content.Bytes())
 		}
 	}
-	w.Write([]byte(stringRepeat(fmt.Sprintf("#1!%d~-\n", SIXEL_BLOCK_SIZE*(code.Size+c.QuietZone*2)), (c.QuietZone-1)*line))) // bottom border
+	w.Write([]byte(stringRepeat(fmt.Sprintf("#1!%d~-\n", SIXEL_BLOCK_SIZE*(code.Size+c.QuietZone*2)), (c.QuietZone)*line))) // bottom border
 	defer w.Write([]byte(SIXEL_END))
 }
 

--- a/qrterminal.go
+++ b/qrterminal.go
@@ -1,9 +1,13 @@
 package qrterminal
 
 import (
+	"bytes"
+	"fmt"
 	"io"
+	"os"
 	"strings"
 
+	"golang.org/x/term"
 	"rsc.io/qr"
 )
 
@@ -24,7 +28,14 @@ const L = qr.L
 // default is 4-pixel-wide white quiet zone
 const QUIET_ZONE = 4
 
-//Config for generating a barcode
+// Sixel Support Control Sequence
+// Color 0: Black Color 1: White
+const SIXEL_BEGIN = "\x1bPq\n#0;2;0;0;0#1;2;100;100;100\n"
+const SIXEL_END = "\x1b\\"
+// Sixel Block Size, should be always greater than 6.
+const SIXEL_BLOCK_SIZE = 12
+
+// Config for generating a barcode
 type Config struct {
 	Level          qr.Level
 	Writer         io.Writer
@@ -34,6 +45,80 @@ type Config struct {
 	WhiteChar      string
 	WhiteBlackChar string
 	QuietZone      int
+	WithSixel      bool
+}
+
+func IsSixelSupported(w io.Writer) bool {
+	if w != os.Stdout {
+		return false
+	}
+	stdout := os.Stdout
+	if !term.IsTerminal(int(stdout.Fd())) {
+		return false
+	}
+	_, err := stdout.Write([]byte("\x1B[c"))
+	if err != nil {
+		return false
+	}
+	buf := make([]byte, 1024)
+	//set echo off
+	raw, err := term.MakeRaw(int(stdout.Fd()))
+	defer term.Restore(int(stdout.Fd()), raw)
+	_, err = stdout.Read(buf)
+	if err != nil {
+		return false
+	}
+	for _, b := range string(buf) {
+		if b == '4' {
+			//Found Sixel Support
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Config) writeSixel(w io.Writer, code *qr.Code) {
+	line := SIXEL_BLOCK_SIZE/6
+	// Frame the barcode in a 1 pixel border
+	w.Write([]byte(SIXEL_BEGIN))
+	w.Write([]byte(stringRepeat(fmt.Sprintf("#1!%d~-\n", SIXEL_BLOCK_SIZE*(code.Size+c.QuietZone*2)), c.QuietZone*line))) // top border
+	for i := 0; i <= code.Size; i++ {
+		flag := -1
+		repeat := 0
+		content := bytes.NewBufferString("")
+		if c.QuietZone > 0 {
+			content.WriteString(fmt.Sprintf("#1!%d~", SIXEL_BLOCK_SIZE*c.QuietZone)) // left border
+		}
+		for j := 0; j <= code.Size; j++ {
+			if code.Black(j, i) {
+				if flag == 1 {
+					content.WriteString(fmt.Sprintf("#1!%d~", SIXEL_BLOCK_SIZE*repeat))
+					repeat = 0
+				}
+				flag = 0
+				repeat++
+			} else {
+				if flag == 0 {
+					content.WriteString(fmt.Sprintf("#0!%d~", SIXEL_BLOCK_SIZE*repeat))
+					repeat = 0
+				}
+				flag = 1
+				repeat++
+			}
+		}
+		if repeat > 0 {
+			content.WriteString(fmt.Sprintf("#%d!%d~", flag, SIXEL_BLOCK_SIZE*repeat))
+		}
+		if c.QuietZone > 1 {
+			content.WriteString(fmt.Sprintf("#1!%d~", SIXEL_BLOCK_SIZE*(c.QuietZone-1))) // right border
+		}
+		content.WriteString("-\n")
+		for i := 0; i < line; i++ {
+			w.Write(content.Bytes())
+		}
+	}
+	w.Write([]byte(stringRepeat(fmt.Sprintf("#1!%d~-\n", SIXEL_BLOCK_SIZE*(code.Size+c.QuietZone*2)), (c.QuietZone-1)*line))) // bottom border
+	defer w.Write([]byte(SIXEL_END))
 }
 
 func (c *Config) writeFullBlocks(w io.Writer, code *qr.Code) {
@@ -121,7 +206,11 @@ func GenerateWithConfig(text string, config Config) {
 	if config.HalfBlocks {
 		config.writeHalfBlocks(w, code)
 	} else {
-		config.writeFullBlocks(w, code)
+		if config.WithSixel {
+			config.writeSixel(w, code)
+		} else {
+			config.writeFullBlocks(w, code)
+		}
 	}
 }
 
@@ -134,6 +223,7 @@ func Generate(text string, l qr.Level, w io.Writer) {
 		WhiteChar: WHITE,
 		QuietZone: QUIET_ZONE,
 	}
+	config.WithSixel = IsSixelSupported(w)
 	GenerateWithConfig(text, config)
 }
 


### PR DESCRIPTION
Add Sixel output Support like #9 .
Sixel format allows us to draw bitmap graphics with compatible terminal application.[iTerm2 on macOS or VSCode with `"terminal.integrated.experimentalImageSupport": true`] The bitmap will be rendered in pixels instead of characters so the qrcode will be much easier to scan especially in a large-font-size terminal.
See https://www.arewesixelyet.com/ for more infos. 
This PR add `writeSixel` to write Sixel Format bitmap and `IsSixelSupported` to check if terminal support the feature, but I only enable it on FullBlock scenario.
👇🏻 A comparison demo.
<img width="579" alt="image" src="https://github.com/mdp/qrterminal/assets/44310445/f82ff239-2aef-4d0f-9119-b1ad8f6ae230">
