### PR TITLE
Fix panic in IsSixelSupported

### DIFF
--- a/qrterminal.go
+++ b/qrterminal.go
@@ -64,6 +64,9 @@ func IsSixelSupported(w io.Writer) bool {
 	buf := make([]byte, 1024)
 	//set echo off
 	raw, err := term.MakeRaw(int(stdout.Fd()))
+	if err != nil {
+		return false
+	}
 	defer term.Restore(int(stdout.Fd()), raw)
 	_, err = stdout.Read(buf)
 	if err != nil {


### PR DESCRIPTION
Hello!

I have been using qrterminal for some time and it is great! Recently I updated to 3.2.1 and I am experiencing a panic on Windows Terminal with Git Bash.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x5c22df]

goroutine 1 [running]:
golang.org/x/term.restore(...)
        C:/Users/cbednarski/go/pkg/mod/golang.org/x/term@v0.32.0/term_windows.go:45
golang.org/x/term.Restore(...)
        C:/Users/cbednarski/go/pkg/mod/golang.org/x/term@v0.32.0/term.go:45
github.com/mdp/qrterminal/v3.IsSixelSupported({0x9f9740?, 0xc000088060?})
        C:/Users/cbednarski/go/pkg/mod/github.com/mdp/qrterminal/v3@v3.2.1/qrterminal.go:70 +0x1b0
github.com/mdp/qrterminal/v3.Generate({0xc000484100, 0x19}, 0xc0002add20?, {0x9f9740?, 0xc000088060?})
        C:/Users/cbednarski/go/pkg/mod/github.com/mdp/qrterminal/v3@v3.2.1/qrterminal.go:247 +0x93
main.PreviewCommand(0xc0002c53c0)
```

This is caused by an unhandled error in `IsSixelSupported`.

```golang
	raw, err := term.MakeRaw(int(stdout.Fd()))  <-- unhandled error
	defer term.Restore(int(stdout.Fd()), raw)   <-- panics when the function returns
```

This PR adds the missing error handling.

I am not sure whether it is feasible to add a test since it is environment specific, but please let me know if you would like any further changes. Thanks!